### PR TITLE
Tests for application form reject names with nunmbers

### DIFF
--- a/ouroboros/hacker/tests/form_tests/application.py
+++ b/ouroboros/hacker/tests/form_tests/application.py
@@ -16,3 +16,31 @@ class ApplicationModelFormTestCase(test.SharedTestCase):
             self.application_fields, self.resume_file_data
         )
         self.assertTrue(form.is_valid())
+
+    def test_isnt_valid_when_first_name_has_numbers(self):
+        self.create_active_wave()
+        hacker_fields = {
+            'email': self.email,
+            'password': self.password,
+            'first_name': 'Bobby432B',
+            'last_name': self.last_name,
+            'is_active': True
+        }
+        form = forms.ApplicationModelForm(
+            hacker_fields
+        )
+        self.assertFalse(form.is_valid())
+
+    def test_isnt_valid_when_last_name_has_numbers(self):
+        self.create_active_wave()
+        hacker_fields = {
+            'email': self.email,
+            'password': self.password,
+            'first_name': self.first_name,
+            'last_name': 'Bob321B',
+            'is_active': True
+        }
+        form = forms.ApplicationModelForm(
+            hacker_fields
+        )
+        self.assertFalse(form.is_valid())


### PR DESCRIPTION
Added a form test to ensure that users can not register with a first or last name that contains any numbers.