### PR TITLE
NO_MORE_WAVES is now handled by the Status template

### DIFF
--- a/ouroboros/templates/hacker/status.html
+++ b/ouroboros/templates/hacker/status.html
@@ -125,7 +125,11 @@
         </div>
       {% elif CANT_MAKE_IT %}
       <p>We're sorry to hear you can't make it! Thanks for telling us!</p>
-      </div>{%endif%}
+      </div>
+      {% elif NO_MORE_WAVES %}
+      <p>Sorry, we have closed registration and are longer accepting applications.</p>
+      </div>
+      {%endif%}
     </div>
     
 </div>


### PR DESCRIPTION
Added a message to the status template that says "Sorry, we have closed registration and are longer accepting applications" whenever there are no more registration waves.