### PR TITLE
Fixed status bug

### DIFF
--- a/hiss/application/models.py
+++ b/hiss/application/models.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Optional
 
 from django.conf import settings
 from django.core import exceptions
@@ -207,23 +208,27 @@ QUESTION3_TEXT = f"What is a cool prize you'd like to win at {settings.EVENT_NAM
 
 
 class WaveManager(models.Manager):
-    def next_wave(self, start_dt: timezone.datetime = timezone.now()):
+    def next_wave(self, start_dt: Optional[timezone.datetime] = None):
         """
         Returns the next INACTIVE wave, if one exists. For the CURRENT active wave, use
         `active_wave`.
         """
+        if not start_dt:
+            start_dt = timezone.now()
         qs = self.get_queryset().filter(start__gt=start_dt).order_by("start")
         return qs.first()
 
-    def active_wave(self, start_dt: timezone.datetime = timezone.now()):
+    def active_wave(self, start_dt: Optional[timezone.datetime] = None):
         """
         Returns the CURRENTLY active wave, if one exists. For the next INACTIVE wave, use
         `next_wave`.
         """
+        if not start_dt:
+            start_dt = timezone.now()
         qs = (
             self.get_queryset()
-            .filter(start__lte=start_dt, end__gt=start_dt)
-            .order_by("start")
+                .filter(start__lte=start_dt, end__gt=start_dt)
+                .order_by("start")
         )
         return qs.first()
 
@@ -328,7 +333,7 @@ class Application(models.Model):
         choices=AGREE,
         default=None,
         help_text="Please note that freshmen under 18 must be accompanied by an adult or prove that they go to Texas "
-        "A&M.",
+                  "A&M.",
     )
     transport_needed = models.CharField(choices=TRANSPORT_MODES, max_length=11)
     additional_accommodations = models.TextField(

--- a/hiss/application/models.py
+++ b/hiss/application/models.py
@@ -227,8 +227,8 @@ class WaveManager(models.Manager):
             start_dt = timezone.now()
         qs = (
             self.get_queryset()
-                .filter(start__lte=start_dt, end__gt=start_dt)
-                .order_by("start")
+            .filter(start__lte=start_dt, end__gt=start_dt)
+            .order_by("start")
         )
         return qs.first()
 
@@ -333,7 +333,7 @@ class Application(models.Model):
         choices=AGREE,
         default=None,
         help_text="Please note that freshmen under 18 must be accompanied by an adult or prove that they go to Texas "
-                  "A&M.",
+        "A&M.",
     )
     transport_needed = models.CharField(choices=TRANSPORT_MODES, max_length=11)
     additional_accommodations = models.TextField(


### PR DESCRIPTION
Closes #164 

According to the [Python docs](https://docs.python.org/3.7/reference/compound_stmts.html#function-definitions), default values for function parameters aren't re-created every time the function is called, but rather created once when Python starts, and re-used every time.

That means that the `WaveManager` methods that use a default `timezone.datetime` for `start_dt` will _create_ `start_dt` one time (when the server starts), and re-use that value every time those methods are called.