### PR TITLE
Mass emails with HTML content.

### DIFF
--- a/hiss/application/admin.py
+++ b/hiss/application/admin.py
@@ -4,14 +4,13 @@ from typing import List, Tuple
 
 from django import forms
 from django.conf import settings
-from django.utils.html import strip_tags
 from django.contrib import admin
-from django.core.mail import get_connection, EmailMultiAlternatives
 from django.db import transaction
 from django.db.models.query import QuerySet
 from django.http import HttpRequest, HttpResponse
 from django.template.loader import render_to_string
 from django.utils import timezone
+from django.utils.html import strip_tags
 from rangefilter.filter import DateRangeFilter
 
 from application.models import Application, Wave

--- a/hiss/application/admin.py
+++ b/hiss/application/admin.py
@@ -40,7 +40,7 @@ def create_rsvp_deadline(user: User, deadline: timezone.datetime) -> None:
 
 
 def build_approval_email(
-        application: Application, rsvp_deadline: timezone.datetime
+    application: Application, rsvp_deadline: timezone.datetime
 ) -> Tuple[str, str, str, None, List[str]]:
     """
     Creates a datatuple of (subject, message, html_message, from_email, [to_email]) indicating that a `User`'s

--- a/hiss/application/tests/admin_tests/application.py
+++ b/hiss/application/tests/admin_tests/application.py
@@ -23,22 +23,22 @@ class ApplicationAdminTestCase(test_case.SharedTestCase):
     def test_approval_email_customizes_event_name(self):
         event_name = "BIGGEST HACKATHON EVER"
         with self.settings(EVENT_NAME=event_name):
-            subject, _, _, _ = build_approval_email(self.app, timezone.now())
+            subject, *_ = build_approval_email(self.app, timezone.now())
             self.assertIn(event_name, subject)
 
     def test_approval_email_customizes_user_first_name(self):
-        _, message, _, _ = build_approval_email(self.app, timezone.now())
+        _, message, *_ = build_approval_email(self.app, timezone.now())
 
         self.assertIn(self.app.first_name, message)
 
     def test_rejection_email_customizes_event_name(self):
         event_name = "BIGGEST HACKATHON EVER"
         with self.settings(EVENT_NAME=event_name):
-            subject, _, _, _ = build_rejection_email(self.app)
+            subject, *_ = build_rejection_email(self.app)
             self.assertIn(event_name, subject)
 
     def test_rejection_email_customizes_first_name(self):
-        _, message, _, _ = build_rejection_email(self.app)
+        _, message, *_ = build_rejection_email(self.app)
 
         self.assertIn(self.app.first_name, message)
 

--- a/hiss/shared/admin_functions.py
+++ b/hiss/shared/admin_functions.py
@@ -1,8 +1,9 @@
 from django.core.mail import get_connection, EmailMultiAlternatives
 
 
-def send_mass_html_mail(datatuple, fail_silently=False, user=None, password=None,
-                        connection=None):
+def send_mass_html_mail(
+    datatuple, fail_silently=False, user=None, password=None, connection=None
+):
     """
     Given a datatuple of (subject, text_content, html_content, from_email,
     recipient_list), sends each message to each recipient list. Returns the
@@ -16,10 +17,11 @@ def send_mass_html_mail(datatuple, fail_silently=False, user=None, password=None
     (from <a href="https://stackoverflow.com/a/10215091">this StackOverflow answer</a>
     """
     connection = connection or get_connection(
-        username=user, password=password, fail_silently=fail_silently)
+        username=user, password=password, fail_silently=fail_silently
+    )
     messages = []
     for subject, text, html, from_email, recipient in datatuple:
         message = EmailMultiAlternatives(subject, text, from_email, recipient)
-        message.attach_alternative(html, 'text/html')
+        message.attach_alternative(html, "text/html")
         messages.append(message)
     return connection.send_messages(messages)

--- a/hiss/shared/admin_functions.py
+++ b/hiss/shared/admin_functions.py
@@ -1,0 +1,25 @@
+from django.core.mail import get_connection, EmailMultiAlternatives
+
+
+def send_mass_html_mail(datatuple, fail_silently=False, user=None, password=None,
+                        connection=None):
+    """
+    Given a datatuple of (subject, text_content, html_content, from_email,
+    recipient_list), sends each message to each recipient list. Returns the
+    number of emails sent.
+
+    If from_email is None, the DEFAULT_FROM_EMAIL setting is used.
+    If auth_user and auth_password are set, they're used to log in.
+    If auth_user is None, the EMAIL_HOST_USER setting is used.
+    If auth_password is None, the EMAIL_HOST_PASSWORD setting is used.
+
+    (from <a href="https://stackoverflow.com/a/10215091">this StackOverflow answer</a>
+    """
+    connection = connection or get_connection(
+        username=user, password=password, fail_silently=fail_silently)
+    messages = []
+    for subject, text, html, from_email, recipient in datatuple:
+        message = EmailMultiAlternatives(subject, text, from_email, recipient)
+        message.attach_alternative(html, 'text/html')
+        messages.append(message)
+    return connection.send_messages(messages)


### PR DESCRIPTION
Closes #264. [`send_mass_mail`](https://docs.djangoproject.com/en/2.2/_modules/django/core/mail/#send_mass_mail) doesn't actually use HTML content (for some reason), so I created a `send_mass_html_mail` based on [`this StackOverflow answer`](https://stackoverflow.com/a/10215091).