### PR TITLE
fixed lack of space between team member names

### DIFF
--- a/hiss/templates/team/team_detail.html
+++ b/hiss/templates/team/team_detail.html
@@ -19,11 +19,9 @@
 
         <div class="col-12 col-md-6">
             <h4>Team Members</h4>
-            <ul>
-                {% for application in member_applications %}
-                    <li>{{ application.first_name }} {{ application.last_name }} </li>
-                {% endfor %}        
-            </ul>
+            {% for application in member_applications %}
+                <h5>{{ application.first_name }} {{ application.last_name }}</h5>
+            {% endfor %}
         </div>
     </div>
     


### PR DESCRIPTION
On the team detail page, the list of team members has been changed from being side-by-side to one on top of the other.