### PR TITLE
Changed text after submitting application

### DIFF
--- a/hiss/templates/status/status.html
+++ b/hiss/templates/status/status.html
@@ -54,10 +54,8 @@
                 <div class="app-status">INCOMPLETE</div>
 
                 <p class="status-subtitle pt-2" style="margin-bottom: 0;">
-                    Submit your application before {{ active_wave_end }} {{ TIME_ZONE }} to be considered during
-                    this wave.
-                    Don't worry,
-                    though! You can still apply after the deadline as part of another wave.
+                    Submit your application before {{ active_wave_end }} {{ TIME_ZONE }} to be considered.
+                    Don’t worry, though! You can still apply as a walk-in, but your spot is not guaranteed.
                 </p>
 
                 <div class="row login-alt-options pt-4">


### PR DESCRIPTION
Changed  "Submit your application before Dec. 20, 2019, 11:59 p.m. US/Central to be considered during this wave. Don’t worry, though! You can still apply after the deadline as part of another wave."