### PR TITLE
Added CORS for volunteer checkin.

### DIFF
--- a/hiss/hiss/settings/base.py
+++ b/hiss/hiss/settings/base.py
@@ -37,11 +37,13 @@ INSTALLED_APPS = [
     "django_admin_listfilter_dropdown",
     "rest_framework",
     "rest_framework.authtoken",
+    "corsheaders",
 ]
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -97,3 +99,8 @@ STATICFILES_DIRS = [os.path.join(BASE_DIR, "..", "static/")]
 STATIC_ROOT = "public/"
 APPEND_SLASH = True
 AUTH_USER_MODEL = "user.User"
+
+# TODO(SaltyQuetzals): Remove http://localhost:3000 for day-of
+CORS_ORIGIN_WHITELIST = ["https://volunteer.tamuhack.com", "http://localhost:3000"]
+
+CORS_URLS_REGEX = r"^/api/.*$"

--- a/hiss/requirements.txt
+++ b/hiss/requirements.txt
@@ -27,7 +27,6 @@ isort==4.3.21
 lazy-object-proxy==1.4.2
 mccabe==0.6.1
 phonenumbers==8.10.15
-pkg-resources==0.0.0
 protobuf==3.10.0
 psycopg2-binary==2.8.3
 pyasn1==0.4.7

--- a/hiss/requirements.txt
+++ b/hiss/requirements.txt
@@ -8,6 +8,7 @@ Django==2.2.8
 django-admin-list-filter-dropdown==1.0.2
 django-admin-rangefilter==0.5.0
 django-anymail==7.0.0
+django-cors-headers==3.2.0
 django-multiselectfield==0.1.8
 django-phonenumber-field==3.0.1
 django-storages==1.7.2
@@ -26,6 +27,7 @@ isort==4.3.21
 lazy-object-proxy==1.4.2
 mccabe==0.6.1
 phonenumbers==8.10.15
+pkg-resources==0.0.0
 protobuf==3.10.0
 psycopg2-binary==2.8.3
 pyasn1==0.4.7
@@ -38,6 +40,7 @@ pylint-plugin-utils==0.5
 pypng==0.0.20
 PyQRCode==1.2.1
 pytz==2019.2
+qrtools==0.0.2
 requests==2.22.0
 rsa==4.0
 six==1.12.0


### PR DESCRIPTION
Added [`django-cors-headers`](https://github.com/adamchainz/django-cors-headers) to Django, and enabled **C**ross **O**rigin **R**esource **S**haring for the `/api/volunteer` routes. This is a sacrifice we have to make because the volunteer app uses React instead of React-Native. This is a slightly increased security risk.

Domains enabled for CORS:
1. `https://volunteer.tamuhack.com`
2. `http://localhost:3000`.

By **January 25, 2020**, we need to remove `http://localhost:3000`.