### PR TITLE
redirect root page to status page instead of login

### DIFF
--- a/hiss/hiss/urls.py
+++ b/hiss/hiss/urls.py
@@ -33,7 +33,7 @@ urlpatterns = [
     path("accounts/", include("customauth.urls")),
     path("application/", include("application.urls", namespace="application")),
     path("healthy/", healthcheck),
-    re_path(r"^$", RedirectView.as_view(pattern_name="customauth:login")),
+    re_path(r"^$", RedirectView.as_view(pattern_name="status")),
     path("status/", include("status.urls")),
     path("api/volunteer/", include("volunteer.urls")),
     *static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT),


### PR DESCRIPTION
Going to the root page always redirected to the login page, even if already logged in. 
Now it redirects to the status page instead, which already handles checking if a user is authenticated. 
If the user is not logged in, the status page redirects them to the login page. if they are logged in, they're just shown their status.