### PR TITLE
create post request in volunteer verify route

### DIFF
--- a/hiss/volunteer/views.py
+++ b/hiss/volunteer/views.py
@@ -43,6 +43,10 @@ class VerifyAuthenticatedView(views.APIView):
         BTW these requests expect the "Authorization" header to be set to "Token <token>"
         """
         return response.Response(status=status.HTTP_200_OK)
+    
+    def post(self, request: Request, format: str | None = None):
+        """same as above but slither is using post method to verify. Not changing it in slither since i don't know if that could break something"""
+        return response.Response(status=status.HTTP_200_OK)
 
 
 class CheckinHackerView(views.APIView):


### PR DESCRIPTION
So slither uses a POST request to verify user credentials (slither/src/lib/slitherAuth.ts), but there was no post request defined in that route (https://register.tamuhack.com/api/volunteer/verify). I could've changed the slither call to a GET method but I wasn't sure if that would break something so I instead just defined the POST method here (same content as GET). 