### PR TITLE
Accept only pdfs for resume upload

### DIFF
--- a/hiss/application/models.py
+++ b/hiss/application/models.py
@@ -313,6 +313,7 @@ class Application(models.Model):
     @override
     def save(self, *args, **kwargs):
         """Override save to ensure meal group assignment logic is applied."""
+        self.full_clean()
         self.assign_meal_group()
         super().save(*args, **kwargs)
 


### PR DESCRIPTION
Fixes bug where file types other than pdf could be uploaded for resume. The code for this was already in place, its just that it wasn't being validated before submitting. 