### PR TITLE
Move captain into the application property

### DIFF
--- a/hiss/application/models.py
+++ b/hiss/application/models.py
@@ -12,7 +12,7 @@ from typing import (
 from django.core import exceptions
 from django.core.validators import FileExtensionValidator
 from django.db import models
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.urls import reverse_lazy
 from django.utils import timezone
 from django_s3_storage.storage import S3Storage
@@ -323,6 +323,7 @@ class Application(models.Model):
         blank=True,
         related_name="members",
     )
+    is_captain = models.BooleanField(default=False)
     status = models.CharField(
         choices=STATUS_OPTIONS, max_length=1, default=STATUS_PENDING
     )
@@ -331,9 +332,15 @@ class Application(models.Model):
         ordering = ["-datetime_submitted"]
         indexes = [
             models.Index(fields=["datetime_submitted"]),
-            models.Index(fields=["school"])
+            models.Index(fields=["school"]),
         ]
-
+        constraints = [
+            models.UniqueConstraint(
+                fields=["team"],
+                condition=Q(is_captain=True),
+                name="unique_team_captain",
+            )
+        ]
 
     @override
     def __str__(self):

--- a/hiss/team/models.py
+++ b/hiss/team/models.py
@@ -24,19 +24,20 @@ class Team(models.Model):
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
 
-    captain = models.OneToOneField(
-        "user.User", on_delete=models.CASCADE, related_name="captained_team"
-    )
     is_active = models.BooleanField(default=True)
 
     objects = TeamQuerySet.as_manager()
 
     @override
     def __str__(self):
-        return f"Team {self.id} (Captain: {self.captain.email})"
+        return f"Team {self.id} (Captain: {self.captain.user.email})"
 
     def get_members(self) -> QuerySet["Application"]:
         return self.members.all()
+
+    @property
+    def captain(self) -> "Application | None":
+        return self.members.filter(is_captain=True).first()
 
     @property
     def is_at_max_capacity(self) -> bool:

--- a/hiss/team/models.py
+++ b/hiss/team/models.py
@@ -30,7 +30,9 @@ class Team(models.Model):
 
     @override
     def __str__(self):
-        return f"Team {self.id} (Captain: {self.captain.user.email})"
+        if self.captain:
+            return f"Team {self.id} (Captain: {self.captain.user.email})"
+        return f"Team {self.id} (No Captain)"
 
     def get_members(self) -> QuerySet["Application"]:
         return self.members.all()


### PR DESCRIPTION
I realized two problems. Sorry for not catching them earlier.

## Problem
1. The captain refers to the user, but the APPLICATION refers to the team. This is kind of odd in many ways. For instance, a user might still be linked as a captain, even if they later down the line decide to make a new, different application.
2. There are two sources of truth, so we can potentially break the database. This is seen in your current iteration of the `CreateTeamView`. While you set the captain of the team in the `Team` table, you did not set the `Application.Team` to the current team. This defies what is supposed to happen.

## Solution
Instead, we will create a single source of truth. The Application table enforces (via a unique constraint) only one Captain per team. Now, Applications only point to the Team table with the FK constraint. The Team table no longer weirdly points to the User table. 

Let me know if I'm actually wrong.